### PR TITLE
feat: add s390x and ppc64le support

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,7 +28,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/quarkus/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/main", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/main", "buildpack.toml"]
+  include-files = ["LICENSE", "NOTICE", "README.md", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/main", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/main", "linux/s390x/bin/build", "linux/s390x/bin/detect", "linux/s390x/bin/main", "linux/ppc64le/bin/build", "linux/ppc64le/bin/detect", "linux/ppc64le/bin/main", "buildpack.toml"]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]
@@ -47,4 +47,12 @@ api = "0.7"
 
 [[targets]]
   arch = "arm64"
+  os = "linux"
+
+[[targets]]
+  arch = "s390x"
+  os = "linux"
+
+[[targets]]
+  arch = "ppc64le"
   os = "linux"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,16 +4,22 @@ set -euo pipefail
 GOMOD=$(head -1 go.mod | awk '{print $2}')
 GOOS="linux" GOARCH="amd64" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
 GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o linux/arm64/bin/main "$GOMOD/cmd/main"
+GOOS="linux" GOARCH="s390x" go build -ldflags='-s -w' -o linux/s390x/bin/main "$GOMOD/cmd/main"
+GOOS="linux" GOARCH="ppc64le" go build -ldflags='-s -w' -o linux/ppc64le/bin/main "$GOMOD/cmd/main"
 
 if [ "${STRIP:-false}" != "false" ]; then
-  strip linux/amd64/bin/main linux/arm64/bin/main
+  strip linux/amd64/bin/main linux/arm64/bin/main linux/s390x/bin/main linux/ppc64le/bin/main
 fi
 
 if [ "${COMPRESS:-none}" != "none" ]; then
-  $COMPRESS linux/amd64/bin/main linux/arm64/bin/main
+  $COMPRESS linux/amd64/bin/main linux/arm64/bin/main linux/s390x/bin/main linux/ppc64le/bin/main
 fi
 
 ln -fs main linux/amd64/bin/build
 ln -fs main linux/arm64/bin/build
+ln -fs main linux/s390x/bin/build
+ln -fs main linux/ppc64le/bin/build
 ln -fs main linux/amd64/bin/detect
 ln -fs main linux/arm64/bin/detect
+ln -fs main linux/s390x/bin/detect
+ln -fs main linux/ppc64le/bin/detect


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Updates `buildpack.toml` and `scripts/build.sh` to add build support for the `s390x` and `ppc64le` architectures. This ensures the Go binaries for the buildpack are correctly compiled, stripped, compressed, and packaged for the new architectures.
rel : https://github.com/paketo-buildpacks/jammy-tiny-stack/pull/257
## Use Cases
This change provides native support for compiling and running the Quarkus buildpack on IBM Z (`s390x`) and IBM Power (`ppc64le`) systems, expanding the ecosystem's cross-platform compatibility.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
